### PR TITLE
Skip dom IDs that do not have text.

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -322,7 +322,8 @@ function parseDocument() {
 		// are re-included as-is, but otherwise are not considered readable text.
 		// Sometimes I see ads being re-included with undefined ids, so it's probably
 		// a good thing to skip these. 
-		if (id !== undefined && $(`#${id}`).is(":visible")) {
+		let el = $(`#${id}`);
+		if (id !== undefined && el.is(":visible") && el.text().length > 0) {
 			readableDomIds.push(id);
 		}
 	});


### PR DESCRIPTION
For some reason readability includes these as output.

This actually fixes two issues, yay!