### PR TITLE
Changed all readableDomIds to readableDomEls.

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -60,7 +60,7 @@ Params:
 */
 // Handle click events for each readable item.
 function setupClickListener(tracker) {
-	for (let i = 0; i < tracker.readableDomIds.length; i++) {
+	for (let i = 0; i < tracker.getReadableDomEls().length; i++) {
 		let container = tracker.getContainer(i);
 		container.click(function () {
 			tracker.pointToContainer(i);
@@ -167,9 +167,7 @@ function moveDownOne() { // Sets start and end
 		return;
 	}
 	tracker.moveNext();
-	let readableDomIds = tracker.getReadableDomIds();
-	let containerId = tracker.getContainerId();
-	display.updateTimer(readableDomIds, containerId);
+	display.updateTimer(tracker.getReadableDomEls(), tracker.getContainerId());
 	highlight(tracker);
 	scrollDown();
 }
@@ -328,10 +326,10 @@ function readListener() {
 			case 'Space': // Switch to auto mode
 				if (timer) {
 					stopMove();
-					display.updateTimer(readableDomIds, tracker.getContainerId());
+					display.updateTimer(tracker.getReadableDomEls(), tracker.getContainerId());
 				} else {
 					startMove(direction.FORWARD);
-					display.updateTimer(readableDomIds, tracker.getContainerId());
+					display.updateTimer(tracker.getReadableDomEls(), tracker.getContainerId());
 				}
 			default:
                 break;
@@ -354,10 +352,10 @@ function init() {
 	// Load all the persistent settings, then render the UI.
 	settings.getSpeed(function(settingsSpeed) {
 		speed = settingsSpeed;
-		let readableDomIds = window.parseDocument();
-		doc = new Doc(readableDomIds);
-		tracker = new Tracker(readableDomIds);
-		display = new Display(readableDomIds, speed, doc.getTotalWords());
+		let readableDomEls = window.parseDocument();
+		doc = new Doc(readableDomEls);
+		tracker = new Tracker(readableDomEls);
+		display = new Display(readableDomEls, speed, doc.getTotalWords());
 
 		setupClickListener(tracker);
 		readListener();

--- a/extension/lib/display.js
+++ b/extension/lib/display.js
@@ -20,12 +20,12 @@ class Display {
     Initialize a display with total time remaining and initial speed (~200 WPM).
 
     Parameters:
-    - readableDomIds: string[]. List of dom IDs that contain readable content.
+    - readableDomEls: $[]. List of jquery dom elements that contain readable content.
     - speed: int. Value proportional to the speed of auto-read mode, before adjustment by sentence length. 
     - total_words: int. Total number of words in readable containers on web page
     */
-    constructor(readableDomIds, speed, total_words) {
-        this.readableDomIds = readableDomIds; // Used to calc initial reading time
+    constructor(readableDomEls, speed, total_words) {
+        this.readableDomEls = readableDomEls; // Used to calc initial reading time
         this.html = null;
         this.time_remaining = null;
         this.reading_speed = speed;
@@ -33,7 +33,7 @@ class Display {
         this.auto_mode = false;
 
         this.defineHtml();
-        this.createDisplay(readableDomIds);
+        this.createDisplay(readableDomEls);
         this.updateSpeed(speed);
     }
 
@@ -65,8 +65,8 @@ class Display {
     /*
     Inserts display HTML into webpage. 
     */
-    createDisplay(readableDomIds) {
-        document.getElementById(readableDomIds[0]).insertAdjacentHTML("beforebegin", this.html);
+    createDisplay(readableDomEls) {
+        readableDomEls[0].prepend(this.html);
         document.getElementById("displayContainer").style.opacity = 1; // For smoother transition
     }
 
@@ -78,13 +78,13 @@ class Display {
     /*
     Updates reading timer based on containers after current tracker. 
     */
-    updateTimer(readableDomIds, containerId) { // Call everytime you get to new paragraph
+    updateTimer(readableDomEls, containerId) { // Call everytime you get to new paragraph
         // TODO: Should also update timer if a user is using the autoread mode. 
         let total_words = 0;
         let currentSpeed = this.reading_speed;
-        let remainingContainers = readableDomIds.slice(containerId); // Need to store as own new list, so for loop indexes through this, not old list
+        let remainingContainers = readableDomEls.slice(containerId); // Need to store as own new list, so for loop indexes through this, not old list
         for (var section in remainingContainers) {    // Calc total words
-            let text = $("#" + remainingContainers[section]).text();
+            let text = remainingContainers[section].text();
             // Regex that will not include numbers: /\b[^\d\W]+\b/g
             let wordRegex = /\b\w+\b/g; // Checks for words
             let wordList = text.match(wordRegex);

--- a/extension/lib/doc.js
+++ b/extension/lib/doc.js
@@ -13,14 +13,14 @@ Note: Called "Doc" because Document is already used in js.
 */
 
 class Doc {
-    constructor(readableDomIds) {
-        this.readableDomIds = readableDomIds; // string[]; List of all container IDs
+    constructor(readableDomEls) {
+        this.readableDomEls = readableDomEls; // $[]; List of all jquery readable containers.
         this.containerId = null; // str; ID of current container
         this.termFreq = null; // { str : int } , Frequency of terms in document. Set in calcTotalWords function
-        this.total_words = this.calcTotalWords(readableDomIds); // int; Total number of words in document;
+        this.total_words = this.calcTotalWords(readableDomEls); // int; Total number of words in document;
         this.keywords = this.setKeyWords(this.termFreq); // string[] keywords of document
         this.container_sentences_map = null; // int[], Index[i] is # of sentneces in ith container, This is set by calcTotalSentences()
-        this.total_sentences = this.calcTotalSentences(readableDomIds);
+        this.total_sentences = this.calcTotalSentences(readableDomEls);
     };
 
     // Returns: Total words in doc (int)
@@ -33,15 +33,6 @@ class Doc {
         return this.keywords;
     }
 
-    // TO DO: REFACTOR; redundant with an identical function in tracker.js
-    // Returns: Container given container ID (jQuery element)
-    getContainer(containerId) {
-        if (containerId === null || containerId < 0 || containerId >= this.readableDomIds.length) {
-            throw `Invalid ${containerId}, should be [0, ${this.readableDomIds.length})`;
-        }
-        return $("#" + this.readableDomIds[containerId]);
-    }
-
     // Returns: Container-sentences map; tells how many sentences are in each container
     getContainerSentencesMap() {
         return this.container_sentences_map;
@@ -51,12 +42,12 @@ class Doc {
     Returns: Total words in document (int)
     Calculates total words in the document
     */
-    calcTotalWords(readableDomIds) {
+    calcTotalWords(readableDomEls) {
         var termFreq = {};
         var total_words = 0;
         var stop_words = new Set(["succeeded", "a", "about", "above", "after", "again", "against", "all", "am", "an", "and", "any", "are", "aren't", "as", "at", "be", "because", "been", "before", "being", "below", "between", "both", "but", "by", "can't", "cannot ", "could", "couldn't", "did", "didn't", "do", "does", "doesn't", "doing", "don't", "down", "during", "each", "few", "for", "from", "further", "had", "hadn't", "has", "hasn't", "have", "haven't", "having", "he", "he'd", "he'll", "he's", "her", "here", "here's", "hers", "herself ", "him", "himself", "his", "how", "however", "how's", "i", "i'd", "i'll", "i'm", "i've", "if", "in", "into", "is", "isn't", "it", "it's", "its", "itself", "let's", "me", "more", "most", "mustn't", "my", "myself", "no", "nor", "not", "of", "off ", "on", "once", "only", "or", "other", "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "shan’t", "she", "she'd", "she'll", "she's", "should", "shouldn't", "so", "some", "such", "than", "that", "that's", "the", "their", "theirs", "them", "themselves", "then", "there", "there's", "these", "they", "they'd", "they'll", "they're", "they've", "this", "those", "through", "to", "too", "under", "until", "up", "very", "was", "wasn't", "we", "we'd", "we'll", "we're", "we've", "were", "weren't", "what", "what's", "when", "when's", "where", "where's", "which", "while", "who", "who's", "whom", "why", "why's", "with", "won't", "would", "wouldn't", "you", "you'd", "you'll", "you're", "you've", "your", "yours", "yourself", "yourselves"]);
-        for (var section in readableDomIds) {
-            let text = this.getContainer(section).text();
+        for (var section in readableDomEls) {
+            let text = readableDomEls[section].text();
             let wordRegex = /\b\w+\b/g;
             let wordList = text.match(wordRegex);
             for (var i in wordList) {
@@ -80,11 +71,11 @@ class Doc {
     Params: Current container ID
     Returns: # of sentences in document, starting from current container
     */
-    calcTotalSentences(readableDomIds) {
+    calcTotalSentences(readableDomEls) {
         let total_sentences = 0;
         let container_sentences_map = []; // For each container, add # of sentences in it
-        for (var section in readableDomIds) {
-            let text = this.getContainer(section).text();
+        for (var section in readableDomEls) {
+            let text = readableDomEls[section].text();
             let start = 0;
             let end = 0;
             var container_sentences = 0;

--- a/extension/lib/document_parser.js
+++ b/extension/lib/document_parser.js
@@ -17,7 +17,7 @@ How:
 - Run Readability to filter for the good elements.
 - Return back the leftover unique ids.
 Returns:
-- readableDomIds - Dom IDs of readable content to initialize the tracker with.
+- readableDomEls - jquery dom elements of readable content to initialize the tracker with.
 */
 function parseDocument() {
 	// Get all direct + indirect descendants of body that are visible.
@@ -28,7 +28,7 @@ function parseDocument() {
 		$(this).uniqueId();
 	});
 
-	let readableDomIds = [];
+	let readableDomEls = [];
 	// Pass clone of document because readability mutates the document.
 	let docClone = document.cloneNode(/* deep= */true);
 	trimDocBasedOnSite(docClone);
@@ -44,15 +44,15 @@ function parseDocument() {
 		// a good thing to skip these. 
 		let el = $(`#${id}`);
 		if (id !== undefined && el.is(":visible") && el.text().length > 0) {
-			readableDomIds.push(id);
+			readableDomEls.push(el);
 		}
 	});
-	return readableDomIds;
+	return readableDomEls;
 	// Uncomment this if you want to see the readable partitions.
 	/*
 		let colors = ['yellow', 'blue'];
-		for (let i = 0; i < readableDomIds.length; i++) {
-			let el = $("#" + readableDomIds[i]);
+		for (let i = 0; i < readableDomEls.length; i++) {
+			let el = readableDomEls[i];
 			console.log((i + 1) + ". " + el.html());
 			el.css({ "background-color": colors[i % colors.length], "opacity": ".20" });
 		}

--- a/extension/lib/tracker.js
+++ b/extension/lib/tracker.js
@@ -20,17 +20,17 @@ class Tracker {
     Initialize a tracker that is not tracking anything.
 
     Parameters:
-    - readableDomIds: string[]. List of dom IDs that contain readable content.
+    - readableDomEls: $[]. List of jquery dom elements that contain readable content.
     */
-    constructor(readableDomIds) {
-        // List of dom IDs that contain readable content.
+    constructor(readableDomEls) {
+        // List of jquery dom elements that contain readable content.
         // Sorted in order of reading progression. 
-        // E.g. $("#" + readableDomIds[0]) gets you the jQuery element to the first readable content.
+        // E.g. readableDomEls[0] gets you the jQuery element to the first readable content.
         // Populated by parseDocument()
-        this.readableDomIds = readableDomIds;
-        // Int. Pointer to an element in readableDomIds. The current container the tracker is in.
+        this.readableDomEls = readableDomEls;
+        // Int. Pointer to an element in readableDomEls. The current container the tracker is in.
         // If there is no tracker yet, this value is null.
-        // Otherwise, it will be in [0, readableDomIds.length)
+        // Otherwise, it will be in [0, readableDomEls.length)
         this.containerId = null;
         // jQuery element. Must be kept in sync with containerId.
         // This is a performance optimization to address the fact that jQuery lookups are not cached.
@@ -48,9 +48,9 @@ class Tracker {
         return this.containerId !== null;
     }
 
-    // Returns: List of readable container IDs on web page
-    getReadableDomIds() {
-        return this.readableDomIds;
+    // Returns: List of readable jquery dom elements on web page
+    getReadableDomEls() {
+        return this.readableDomEls;
     }
     // Returns: Container ID of current container
     getContainerId() {
@@ -66,14 +66,6 @@ class Tracker {
         this.start = 0;
         // TODO: Does jquery cache the container text?
         this.end = this.getSentenceEnd(this.container.text(), this.start);
-    }
-    // Returns: List of readable container IDs on web page
-    getReadableDomIds() {
-        return this.readableDomIds;
-    }
-    // Returns: Container ID of current container
-    getContainerId() {
-        return this.containerId;
     }
     /*
     Returns:
@@ -108,16 +100,15 @@ class Tracker {
     }
     
     /*
-    Get the jquery container from readableDomIds corresponding to containerId.
-    Note that this invokes jQuery lookup, and so caller should try to cache the result.
+    Get the jquery container corresponding to containerId.
 
     Throws exception on invalid container id.
     */
     getContainer(containerId) {
-        if (containerId === null || containerId < 0 || containerId >= this.readableDomIds.length) {
-            throw `Invalid ${containerId}, should be [0, ${this.readableDomIds.length})`;
+        if (containerId === null || containerId < 0 || containerId >= this.readableDomEls.length) {
+            throw `Invalid ${containerId}, should be [0, ${this.readableDomEls.length})`;
         }
-        return $("#" + this.readableDomIds[containerId]);
+        return this.readableDomEls[containerId];
     }
 
     /*
@@ -138,7 +129,7 @@ class Tracker {
         if (new_start >= len) {
             // Reached the end, no more container.
             // Don't update the tracker. Keep pointing to the last element.
-            if (this.containerId >=  this.readableDomIds.length - 1) {
+            if (this.containerId >=  this.readableDomEls.length - 1) {
                 return;
             }
             this.pointToContainer(this.containerId + 1); 


### PR DESCRIPTION
Why:
- More efficient. $("") actually does dom lookup each time.
- Actually needed for the on/off change later on. For some reason re-invoking $("<id>") during callback doesn't capture the click event handlers anymore, so I need consistent direct pointers from now on.

No behavior change, just pure refactor.