### PR TITLE
fix extension not closing w/ alt+r 

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -232,8 +232,7 @@ $(window).scroll(function() {
 Undo all actions by highlight() and highlightKeyWords().
 */
 function unhighlightEverything() {
-  // TODO: If this is broken, make a tracker class that never changes. Then use the ID for styling
-	$("." + trackerClass).unmark(); 
+	$("." + sentenceClass).unmark(); 
 	$("." + keywordClass).unmark();
 }
 


### PR DESCRIPTION
fix extension not closing w/ alt+r because it complained about 'trackerClass' not being a defined variable. tested extension closes now.
