### PR TITLE
Stop app init if too many sentences

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -11,7 +11,7 @@ if (window[namespace] === true) {
 
 // If true, all debugging statements would show.
 // TODO: Use a proper logging library.
-window.DEBUG = true;
+window.DEBUG = false;
 window.debug = function(str) {
 	if (DEBUG) {
 		console.log("DEBUG: " + str);

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -471,7 +471,7 @@ function oneTimeSetup() {
 	doc = new Doc(readableDomEls);
 	// If page is not readable, stop setting up the rest of the app.
 	if (doc.sentences.length === 0) {
-		// TODO:
+		debug("Stopping app init because page is not readable");
 		return;
 	}
 	tracker = new Tracker(doc);

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -454,6 +454,11 @@ In the INACTIVE state, the widgets are not visible, and no event handlers are at
 function oneTimeSetup() {
 	let readableDomEls = window.parseDocument();
 	doc = new Doc(readableDomEls);
+	// If page is not readable, stop setting up the rest of the app.
+	if (doc.sentences.length === 0) {
+		// TODO:
+		return;
+	}
 	tracker = new Tracker(doc);
 	// TODO: Refactor using promise logic so this is more readable.
 	// Load all the persistent settings, then render the UI.
@@ -478,8 +483,6 @@ function setupUI() {
 	window.trackerStyle = trackerStyle; // Expose to global
 	settingsView = new SettingsView();
 	
-
-  
 	updateDisplaySettings();
   
 	setupClickListeners();

--- a/extension/lib/doc.js
+++ b/extension/lib/doc.js
@@ -7,6 +7,9 @@ if (window[namespace] === true) {
     window[namespace] = true;
 }
 
+// If the number of sentences in the doc exceeds this, mark the document as unreadable.
+const MAX_NUM_SENTENCE = 1000;
+
 /*
 All NLP <-> DOM preprocessing logic should reside in this file.
 There are two main core concepts, each concept having an NLP meaning, along with DOM binding.
@@ -86,6 +89,7 @@ class Doc {
     /*
     Find all sentence boundaries within containers.
     Initializes [sentences, containerIdToFirstSentenceId]
+    If document is not readable, sentences will be empty array.
     */
     detectSentenceBoundaries() {
         debug("Detecting sentence boundaries");
@@ -102,6 +106,13 @@ class Doc {
                 let start = sentenceBoundary.index;
                 let end = start + sentenceBoundary.offset;
                 this.sentences.push(new SentencePointer(container_id, start, end));
+            }
+            if (this.sentences.length > MAX_NUM_SENTENCE) {
+                debug("Too many sentences found = " + this.sentences.length);
+                this.containers = [];
+                this.sentences = [];
+                this.containerIdToFirstSentenceId = [];
+                break;
             }
         }
         debug("Number of sentences = " + this.sentences.length);

--- a/extension/lib/doc.js
+++ b/extension/lib/doc.js
@@ -108,7 +108,7 @@ class Doc {
                 this.sentences.push(new SentencePointer(container_id, start, end));
             }
             if (this.sentences.length > MAX_NUM_SENTENCE) {
-                debug("Too many sentences found = " + this.sentences.length);
+                alert("Sorry, we don't support big documents yet :(");
                 this.containers = [];
                 this.sentences = [];
                 this.containerIdToFirstSentenceId = [];

--- a/extension/lib/document_parser.js
+++ b/extension/lib/document_parser.js
@@ -18,6 +18,7 @@ How:
 - Return back the leftover unique ids.
 Returns:
 - readableDomEls - jquery dom elements of readable content to initialize the tracker with.
+  Or empty array if page is not readable.
 */
 function parseDocument() {
 	let hostname = $(location).attr('hostname');

--- a/extension/lib/document_parser.js
+++ b/extension/lib/document_parser.js
@@ -39,8 +39,11 @@ function parseDocument() {
 	let docClone = document.cloneNode(/* deep= */true);
 	trimDocBasedOnSite(docClone, hostname);
 
-	// TODO: Handle readability failures.
 	let article = new Readability(docClone).parse();
+	if (article === null) {
+		return [];
+	}
+
 	// Readability.js converts all readable elements into <p>
 	$(article.content).find("p,h1,h2,h3,li").each(function() {
 		let id = $(this).attr('id');


### PR DESCRIPTION
Don't initialize app if
1. readability doesn't parse the page (e.g. image) or
2. too many sentences (which can cause browser to crash for crappy computers)
