### PR TITLE
Stop using <mark> for sentence. Find sentence by sentence id.

### DIFF
--- a/extension/lib/doc.js
+++ b/extension/lib/doc.js
@@ -114,7 +114,8 @@ class Doc {
                     start: start,
                     length: sentenceBoundary.offset
                 }], {
-                    className: sentenceClassName
+                    className: sentenceClassName,
+                    element: "readerease-sentence"
                 });
                 this.sentenceEls.push($("." + sentenceClassName));
             }

--- a/extension/lib/tracker.js
+++ b/extension/lib/tracker.js
@@ -56,10 +56,10 @@ class Tracker {
     /*
     Point to a sentence given its ID. 
     */
-   pointToSentence(sentenceId) {
+    pointToSentence(sentenceId) {
         this.sentenceId = sentenceId;
-   }
-    
+    }
+
     /*
     Move tracker to the next readable portion, moving across containers if necessary.
     If not currently tracking, will point to the first sentence.


### PR DESCRIPTION
1. Mark element is now "readerease-sentence"  
   Keywords still using mark tho, left a TODO
2. Sentence highlighting / non highlighting are now based on sentence Id's, then adding and removing of classes. This is faster because:
  - There are 0 jquery dom lookups because the sentence jquery els are cached -- vs having to lookup based on class.
  - Also, cos no DOM element is added (we are just adding and removing classes, rather than adding and removing <mark> elements).