### PR TITLE
Removed [hold arrow key = autoplay] behavior

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -413,9 +413,7 @@ function adjustSpeed(speedDelta) {
 
 function setupKeyListeners() {
 	jdoc.on("keydown", function(evt) {
-		if (!document.hasFocus()
-			// Swallow up all inputs while an animation is ongoing to prevent edge cases.
-			|| animationState !== animationEnum.NONE) {
+		if (!document.hasFocus()) {
 		  return true;
 		}
 

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -88,6 +88,7 @@ function setupSentenceClickListeners() {
 		doc.getSentenceEls(sentenceId).on("click", function(e) {          
 			highlight(sentenceId);
 			tracker.pointToSentence(sentenceId);
+			scrollToTracker();
 		});
 	}
 }
@@ -203,23 +204,32 @@ function moveOne(dir) { // Sets start and end
 
 	timeTrackerView.updateTimer(tracker.getSentenceId());
 	highlight(tracker.getSentenceId());
- 
-	if (dir == direction.BACKWARD) {
-		scrollUp();
-	} else if (dir == direction.FORWARD) {
-		scrollDown();
-	}
+	scrollToTracker();
 	return true;
 }
 
-// Scroll up when tracker is above page
-function scrollUp() {
-	let verticalMargin = 200;
+// Manual movement is limited to once 200ms, or else if user taps arrow keys really quickly,
+// or presses down on them, there will be
+// too many UI events (e.g. highlighting, etc.) happening at once, making things very slow.
+// Debounce note: Will execute only after this function is uncalled for that amount of time.
+// The inactivity timer gets reset when function gets called while it is 'recovering'.
+let moveOneDebounced = _.debounce(moveOne, 200);
+
+// Scroll page so tracker is in view.
+function scrollToTracker() {
+	// One animation at a time.
+	if (animationState !== animationEnum.NONE) {
+		return;
+	}
+	let verticalMargin = 100;
+	// The viewing band is from top of the page (0) down to scrollThreshold away
+	let scrollThreshold = 200;
 	// Autoscroll if tracker is above top of page.
 	// Number of pixels from top of window to top of current container.
 	let markedTopAbsoluteOffset = doc.getSentenceEls(tracker.getSentenceId()).offset().top;
 	let markedTopRelativeOffset = markedTopAbsoluteOffset - $(window).scrollTop();
-	if (markedTopRelativeOffset < 0) {
+	if (markedTopRelativeOffset < 0
+		|| markedTopRelativeOffset > scrollThreshold) {
 		animationState = animationEnum.SCROLL;
 		$('html, body').animate(
 			// Leave some vertical margin before the container.
@@ -232,27 +242,6 @@ function scrollUp() {
 	} 
 }
 
-// Scroll down when tracker is below a certain point
-function scrollDown() {
-	let scrollThreshold = 200;
-	let verticalMargin = 100;
-	// Autoscroll if too far ahead.
-	// Number of pixels from top of window to top of current container.
-
-	let markedTopAbsoluteOffset = doc.getSentenceEls(tracker.getSentenceId()).offset().top;
-	let markedTopRelativeOffset = markedTopAbsoluteOffset - $(window).scrollTop();
-	if (markedTopRelativeOffset > scrollThreshold) {
-		animationState = animationEnum.SCROLL;
-		$('html, body').animate(
-			// Leave some vertical margin before the container.
-			{scrollTop: (markedTopAbsoluteOffset - verticalMargin)},
-			SCROLL_DURATION_MS,
-			function() {
-				animationState = animationEnum.NONE;
-			}
-		);
-	}
-}
 // Uncomment this if you want to see the relative y offsets of current container
 // so you can tweak the auto-scroll feature.
 /*
@@ -424,22 +413,21 @@ function setupKeyListeners() {
 
 		switch (evt.code) {
 			case 'ArrowLeft': // Move back
-				stopFadeTracker();
-                startMove(direction.BACKWARD);
+				stopMove();
+                moveOneDebounced(direction.BACKWARD);
                 break;
 			case 'ArrowRight': // Move forward
-				stopFadeTracker();
-                startMove(direction.FORWARD);
+				stopMove();
+                moveOneDebounced(direction.FORWARD);
 				break;
 			case 'KeyD':	// Increase velocity
 				adjustSpeed(40);
 				break;
 			case 'KeyS':	// Slow velocity
 				adjustSpeed(-40);
-				break;
+				break;dd
 			case 'Space': // Switch to auto mode
 				if (timer) {
-					stopFadeTracker();
 					stopMove();
 				} else {
 					startMove(direction.FORWARD);
@@ -447,20 +435,12 @@ function setupKeyListeners() {
 				break;
 			case 'ShiftRight':
 				persistentHighlight();
+				break;
 			default:
                 break;
 		}
 		return true;
 	});
-	jdoc.on("keyup", function(evt) {
-		switch (evt.code) {
-			case 'ArrowLeft':
-			case 'ArrowRight':
-				stopMove();
-				break;
-		}
-		return true;
-    });
 };
 
 // Classname for keyword highlights.

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -18,6 +18,18 @@ window.debug = function(str) {
 	}
 }
 
+
+// Mutually exclusive current animation state.
+const animationEnum = {
+	// No animation right now. Everything is static
+	NONE: "none",
+	// Page is scrolling
+	SCROLL: "scroll",
+	// Intersentence transition
+	// TODO: Use this when implementing sentence transition.
+	TRANSITION: "transition"
+}
+
 const keywordClass = "keywordClass" // Name of class for FINDING keywords (no styling)
 const SCROLL_DURATION_MS = 500;
 
@@ -40,8 +52,8 @@ var timer = null;
 let speed = null; // WPM, Base speed, not accounting for sentence length; adjustable w/ D/S
 // Persistent settings.
 let settings = window.settings;
-// If the screen is currently scrolling. If it is, pause the tracker.
-var isScrolling = false;
+// Current animation state, to ensure we are not doing multiple animations at once.
+var animationState = animationEnum.NONE;
 
 // Need the same $ reference for on and off of event handlers to be detectable.
 // Re-doing $(document) in an async context for some reason doesn't allow you 
@@ -123,7 +135,7 @@ function startMove(dir) { // Note: I have combined the "moveUp" and "moveDown" f
 	// Schedule continuous movement, with the first move being run immediately.
 	(function repeat() { // Allows speed to be updated WHILE moving
 		// Let scrolling finish before any movement.
-		if (isScrolling) {
+		if (animationState !== animationEnum.NONE) {
 			timer = setTimeout(repeat, SCROLL_DURATION_MS);
 			return;
 		}
@@ -208,13 +220,13 @@ function scrollUp() {
 	let markedTopAbsoluteOffset = doc.getSentenceEls(tracker.getSentenceId()).offset().top;
 	let markedTopRelativeOffset = markedTopAbsoluteOffset - $(window).scrollTop();
 	if (markedTopRelativeOffset < 0) {
-		isScrolling = true;
+		animationState = animationEnum.SCROLL;
 		$('html, body').animate(
 			// Leave some vertical margin before the container.
 			{scrollTop: (markedTopAbsoluteOffset - verticalMargin)},
 			SCROLL_DURATION_MS,
 			function() {
-				isScrolling = false;
+				animationState = animationEnum.NONE;
 			}
 		);
 	} 
@@ -230,13 +242,13 @@ function scrollDown() {
 	let markedTopAbsoluteOffset = doc.getSentenceEls(tracker.getSentenceId()).offset().top;
 	let markedTopRelativeOffset = markedTopAbsoluteOffset - $(window).scrollTop();
 	if (markedTopRelativeOffset > scrollThreshold) {
-		isScrolling = true;
+		animationState = animationEnum.SCROLL;
 		$('html, body').animate(
 			// Leave some vertical margin before the container.
 			{scrollTop: (markedTopAbsoluteOffset - verticalMargin)},
 			SCROLL_DURATION_MS,
 			function() {
-				isScrolling = false;
+				animationState = animationEnum.NONE;
 			}
 		);
 	}
@@ -300,7 +312,7 @@ function highlightKeyWords(container, start, end) {
 	let keywordStyle = trackerStyle.getKeywordStyle(); 
 	$("."+keywordClass).unmark(); // Remove previous sentence keyword styling
 	$("."+keywordClass).removeClass(keywordStyle);
-	$("."+keywordStyle).removeClass(keywordStyle);
+	
 	// Get list of words in interval
 	let containerText = container.text();
 	let sentenceText = containerText.slice(start,end);
@@ -401,7 +413,9 @@ function adjustSpeed(speedDelta) {
 
 function setupKeyListeners() {
 	jdoc.on("keydown", function(evt) {
-		if (!document.hasFocus()) {
+		if (!document.hasFocus()
+			// Swallow up all inputs while an animation is ongoing to prevent edge cases.
+			|| animationState !== animationEnum.NONE) {
 		  return true;
 		}
 

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -425,7 +425,7 @@ function setupKeyListeners() {
 				break;
 			case 'KeyS':	// Slow velocity
 				adjustSpeed(-40);
-				break;dd
+				break;
 			case 'Space': // Switch to auto mode
 				if (timer) {
 					stopMove();

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -134,7 +134,7 @@ function startMove(dir) { // Note: I have combined the "moveUp" and "moveDown" f
 
 	// Schedule continuous movement, with the first move being run immediately.
 	(function repeat() { // Allows speed to be updated WHILE moving
-		// Let scrolling finish before any movement.
+		// When there is animation ongoing, wait for it to finish before doing any movement.
 		if (animationState !== animationEnum.NONE) {
 			timer = setTimeout(repeat, SCROLL_DURATION_MS);
 			return;


### PR DESCRIPTION
This is a preparation for the sentence transition CL.
Arrow key relies directly on moveOne, instead of startMove()
With this decoupling, the next CL will then just focus on changing startMove, while leaving the non-autoplay behavior untouched.
