### PR TITLE
Update timer when click on sentence.

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -89,6 +89,7 @@ function setupSentenceClickListeners() {
 		doc.getSentenceEls(sentenceId).on("click", function(e) {          
 			highlight(sentenceId);
 			tracker.pointToSentence(sentenceId);
+			timeTrackerView.updateTimer(sentenceId);
 			scrollToTracker();
 		});
 	}


### PR DESCRIPTION
Previously for timer to update onclick, you have to additionally tap an arrow key.