### PR TITLE
App-ON stickiness is now based on site.

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -620,6 +620,8 @@ function removeUI() {
 function toggleExtensionVisibility() {
 	// Doc is not readable.
 	if (doc.getNumSentences() === 0) {
+		// Remove load icon
+		removeLoadIcon();
 		return;
 	}
 	if (timeTrackerView === null) {


### PR DESCRIPTION
That is, wikipedia.com and medium.com can be ON by default, whereas other sites have it off by default.
We keep only the 10 most recently ON sites.